### PR TITLE
Refresh public site content from wiki publishing pack

### DIFF
--- a/content/about/personal.md
+++ b/content/about/personal.md
@@ -1,34 +1,49 @@
 ---
 title: "About myself"
-date: 2021-08-30T22:58:15-07:00
+date: 2026-05-31T00:00:00-07:00
 ---
 
-### Hello 👋
+### Hello
 
-Thank you for visiting my personal website. Here are some details about me, the person.
+I am Ranjib Dey, a software engineer focused on production engineering, infrastructure automation, reliability, incident management, and open source systems. My public work spans infrastructure-as-code, testing discipline for operations, Linux containers, service discovery, ML-assisted capacity management, and hardware automation.
 
-- 🔭 I'm a software engineer in Uber's production engineering group, working on day to day web operations
-- 🌱 Currently I'm learning electronics, resiliency engineering (incident management, permaculture) and general leadership skills
-- 👯 I’m looking to collaborate on IoT/Physical computing, resiliency engineering & observability of cloud native application
-- 🤔 I’m looking for help with electronics, specifically complex multi output PSU designs and motor controls
-- 💬 Ask me about web operations, incident management, AIOps, permaculture & reef keeping.
-- 📫 How to reach me: ranjib@linux.com
-- 😄 Pronouns: he
-- ⚡ Fun fact: I am the author of [reef-pi](http://reef-pi.com), winner of Maker Faire Editors choice award, awesome chef [community member](https://github.com/chef/chef/blob/main/CHEF_MVPS.md) award and an ex-maintainer of [chef](https://github.com/chef/chef).
+I currently work on production engineering at Uber. Public artifacts from this era include Uber Engineering Blog work on ML-driven capacity safety and capacity recommendation, talks on incident taxonomy and incident management, and a co-authored USENIX NSDI 2026 paper on Uber's failover architecture.
 
-## Public speaking, experience reports & blogs
+Earlier public work includes Chef and DevOps infrastructure automation at ThoughtWorks and PagerDuty. I was an open source maintainer of Chef, received the Chef Awesome Community Member / MVP award, authored chef-lxc, and wrote and spoke about testing infrastructure code, TDD in operations, CI/CD for Chef, LXC, and Consul.
 
-- Culturing resiliency with Data: A taxonomy of incidents. ChaosConf, December, 2020. [slides](https://www.infoq.com/presentations/uber-outages/)
-- How Uber does incident management. Major Incident Management Expo, November, 2020
-- Using ML for micro service capacity safety. March 7, 2019. [Uber tech blog](https://eng.uber.com/machine-learning-capacity-safety/)
-- Consul at PagerDuty, Hashicorp User Group - SF. November, 2016. [slides](https://speakerdeck.com/ranjibd/consul-at-pagerduty)
-- Strategies for adopting Test Driven)Development in operations . Agile 2015, Washington, D.C. [slides](https://speakerdeck.com/ranjibd/adopting-test-driven-development-in-operations) , [experience report](https://www.agilealliance.org/wp-content/uploads/2015/12/ExperienceReport.2015.Dey_.Strategies_for_adopting_Test_Driven_Development_in_Operations_.pdf)
-- Extending CI/CD in operations using Chef and LXC. LinuxCon - North America, Seattle, 2015. [slides](https://speakerdeck.com/ranjibd/cd-in-operations-using-chef-and-lxc)
-- Chef at PagerDuty blog posts: [Overview](https://www.pagerduty.com/blog/chef-testing-pagerduty/) and [testing](https://www.pagerduty.com/blog/chef-testing-pagerduty/)
-- Chef-LXC - Building and deploying custom containers - Bay area chef meetup, June, 2013. [slides](https://speakerdeck.com/ranjibd/chef-lxc-building-and-deploying-custom-containers)
-- A short introduction to LXC, Bay Area Large Scale production engineering group meetup, February, 2014. [slides](https://speakerdeck.com/ranjibd/a-short-introduction-to-lxc)
-- How to mock a mocking bird. ChefConf, 2014. [slides](https://speakerdeck.com/ranjibd/how-to-mock-a-mocking-bird-testing-dynamic-infrastructure)
-- Attaining Resiliency : Culture, Tools and Practices.  DevopsDays India, 2013. [slides](https://speakerdeck.com/ranjibd/attaining-resiliency-culture-tools-and-practices)
-- Automated infrastructure testing. vodQA-10. October,2012, Pune.[slides](https://www.slideshare.net/ThoughtWorks/automated-infrastructure-testing-ranjib-dey)- 
-- [DZone blogs](https://dzone.com/users/999247/ranjibd.html) on web operations, CI/CD and chef . 2011-2012
-- System automation using Chef. FudCon, Pune. 5th November, 2011
+Outside work, I build and maintain [reef-pi](https://reef-pi.github.io/), an open source Raspberry Pi based reef tank controller. reef-pi has grown from a hobby automation project into a public ecosystem with official guides, community support, hardware integrations, Maker Faire recognition, and coverage from Make:, Adafruit, and the Raspberry Pi Foundation.
+
+## Public work themes
+
+- Infrastructure as code and configuration management with Chef.
+- Testing discipline for operations, including ChefSpec, Test Kitchen, Serverspec/InSpec, and CI for infrastructure code.
+- Linux containers and early LXC-based build and deployment workflows.
+- Service discovery and platform engineering with Consul and distributed systems tooling.
+- SRE, incident management, resiliency engineering, and incident taxonomy.
+- Capacity management and ML-assisted operations at hyperscale.
+- Physical computing, IoT, and open source reef automation through reef-pi.
+
+## Public speaking, papers, and blogs
+
+- Culturing resiliency with Data: A taxonomy of incidents. ChaosConf, 2020. [InfoQ](https://www.infoq.com/presentations/uber-outages/)
+- How Uber does incident management. Major Incident Management Expo, 2020.
+- Using ML for microservice capacity safety. Uber Engineering Blog, 2019. [Uber Engineering](https://www.uber.com/en-US/blog/capacity-recommendation-engine/)
+- Uber's Failover Architecture: Reconciling Reliability and Efficiency in Hyperscale Microservice Infrastructure. USENIX NSDI 2026. [USENIX](https://www.usenix.org/conference/nsdi26/presentation/bansal)
+- Consul at PagerDuty. HashiCorp User Group SF, 2016. [Slides](https://speakerdeck.com/ranjibd/consul-at-pagerduty)
+- Strategies for adopting Test Driven Development in operations. Agile 2015, Washington, D.C. [Slides](https://speakerdeck.com/ranjibd/adopting-test-driven-development-in-operations), [experience report](https://www.agilealliance.org/wp-content/uploads/2015/12/ExperienceReport.2015.Dey_.Strategies_for_adopting_Test_Driven_Development_in_Operations_.pdf)
+- Extending CI/CD in operations using Chef and LXC. LinuxCon North America, 2015. [Slides](https://speakerdeck.com/ranjibd/cd-in-operations-using-chef-and-lxc)
+- Chef at PagerDuty. PagerDuty Engineering Blog. [Post](https://www.pagerduty.com/blog/chef-testing-pagerduty/)
+- Chef-LXC: Building and deploying custom containers. Bay Area Chef Meetup, 2013. [Slides](https://speakerdeck.com/ranjibd/chef-lxc-building-and-deploying-custom-containers)
+- A short introduction to LXC. Bay Area Large Scale Production Engineering group, 2014. [Slides](https://speakerdeck.com/ranjibd/a-short-introduction-to-lxc)
+- How to mock a mocking bird: testing dynamic infrastructure. ChefConf, 2014. [Slides](https://speakerdeck.com/ranjibd/how-to-mock-a-mocking-bird-testing-dynamic-infrastructure)
+- Attaining Resiliency: Culture, Tools and Practices. DevopsDays India, 2013. [Slides](https://speakerdeck.com/ranjibd/attaining-resiliency-culture-tools-and-practices)
+- Automated infrastructure testing. vodQA-10, Pune, 2012. [Slides](https://www.slideshare.net/ThoughtWorks/automated-infrastructure-testing-ranjib-dey)
+- System automation using Chef. FudCon Pune, 2011.
+- [DZone blogs](https://dzone.com/users/999247/ranjibd.html) on web operations, CI/CD, and Chef.
+
+## Profiles and projects
+
+- GitHub: [github.com/ranjib](https://github.com/ranjib)
+- reef-pi: [reef-pi.github.io](https://reef-pi.github.io/)
+- Sessionize: [sessionize.com/ranjib-dey](https://sessionize.com/ranjib-dey/)
+- LinkedIn: [Ranjib Dey](https://www.linkedin.com/in/ranjib-dey-a20b40123)

--- a/content/about/public-profile.md
+++ b/content/about/public-profile.md
@@ -1,0 +1,36 @@
+---
+title: "Public profile blurbs"
+date: 2026-05-31T00:00:00-07:00
+---
+
+These public profile blurbs are reusable for talk proposals, bios, project pages, and outreach. They are derived from public sources only.
+
+## Short bio
+
+Ranjib Dey is a software engineer focused on production engineering, reliability, infrastructure automation, and open source systems. His public work spans Chef, DevOps, SRE, incident management, ML-assisted capacity management, and reef-pi, an open source Raspberry Pi based reef tank controller.
+
+## Medium bio
+
+Ranjib Dey is a software engineer working on production engineering and reliability at Uber. His public work spans infrastructure as code, testing discipline for operations, Linux containers, service discovery, incident management, resiliency engineering, and ML-assisted capacity management. He was an open source maintainer of Chef, received the Chef Awesome Community Member / MVP award, authored chef-lxc, and has presented at venues including ChefConf, LinuxCon, Agile 2015, HashiCorp User Group SF, ChaosConf, and the Major Incident Management Expo. He also builds reef-pi, an open source Raspberry Pi based reef tank controller recognized by Maker Faire and covered by Make:, Adafruit, and the Raspberry Pi Foundation.
+
+## Longer bio
+
+Ranjib Dey is a software engineer focused on production engineering, reliability, platform engineering, and open source systems. His public career arc starts with Chef, infrastructure as code, and testing infrastructure code; continues through TDD in operations, CI/CD for Chef, LXC, and Consul at PagerDuty; and extends into hyperscale production engineering at Uber through public work on ML-driven capacity safety, incident taxonomy, incident management, and failover architecture.
+
+He was an open source maintainer of Chef, received the Chef Awesome Community Member / MVP award, authored chef-lxc, and has published or presented work at FudCon, vodQA, DevopsDays India, ChefConf, LinuxCon North America, Agile 2015, HashiCorp User Group SF, ChaosConf, Major Incident Management Expo, Uber Engineering Blog, and USENIX NSDI 2026. Outside work, he builds reef-pi, an open source Raspberry Pi based reef tank controller with public documentation, hardware ecosystem, community support, Maker Faire recognition, and coverage from Make:, Adafruit, and the Raspberry Pi Foundation.
+
+## Project blurb: reef-pi
+
+reef-pi is an open source Raspberry Pi based reef tank controller. It automates reef-keeping modules including equipment control, temperature, lighting, water level, pH monitoring, dosing, telemetry, dashboards, and macros. The project grew into a public ecosystem with official guides, GitHub repositories, Reef2Reef community support, compatible hardware paths, Maker Faire recognition, and coverage from Make:, Adafruit, and the Raspberry Pi Foundation.
+
+## Project blurb: Chef and infrastructure automation
+
+Ranjib's public Chef work includes Chef maintainer activity, the Chef Awesome Community Member / MVP award, chef-lxc, and a sequence of talks and writing on system automation, infrastructure testing, dynamic infrastructure mocking, TDD in operations, and CI/CD for Chef and LXC. The recurring theme is treating infrastructure changes as software changes: versioned, reviewed, tested, and continuously delivered.
+
+## Speaking topics
+
+- Reliability engineering through incident taxonomy and operational learning.
+- Applying software testing discipline to infrastructure and operations.
+- Platform engineering through automation, service discovery, and safe delivery paths.
+- ML-assisted capacity management and production engineering at scale.
+- Open source physical computing with reef-pi and Raspberry Pi based automation.

--- a/content/posts/about.md
+++ b/content/posts/about.md
@@ -1,8 +1,12 @@
 ---
 title: "About this website"
-date: 2021-08-30T22:57:50-07:00
+date: 2026-05-31T00:00:00-07:00
 ---
 
-I am in process of rebooting my personal website, from jekyll to hugo. I had not updated it for almost 6 years. Lot has changed since then. My son Ryan has joined my life's journey, I have got involved deeper into physical computing, my tech job profile and related tools, languages have also changed significantly. While the old website had some general musing and mostly chef, system automation related content, this new version will reflect my current experience in similar domain but also my hobbies. I take inspiration from different domains and I hope these posts can articulate those learnings.
+This website is my public professional and project archive. It collects writing, talks, papers, open source work, and selected project notes that are safe to publish outside my private knowledge base.
 
-My other blogs, experience reports and conference talk slides are available [here](/about)
+The site is intentionally simple. The content is the main surface: public engineering themes, open source projects, reliability and operations writing, and posts that connect software systems thinking with physical computing projects such as reef-pi.
+
+The current refresh uses a public-only publishing pack generated from my personal LLM wiki. That pack filters for public wiki pages and public source manifests, then produces source-backed context for website updates. Non-public wiki material stays out of the website workflow.
+
+My other blogs, experience reports, conference talks, and profile links are available on the [about page](/about/personal/).

--- a/content/posts/platform-engineering-through-automation.md
+++ b/content/posts/platform-engineering-through-automation.md
@@ -1,0 +1,58 @@
+---
+title: "Platform Engineering Through Automation"
+date: 2026-05-31T00:00:00-07:00
+draft: false
+---
+
+Looking back across my public talks and writing, the same idea keeps returning in different forms: operational work should become software.
+
+In the early 2010s, that meant Chef, infrastructure as code, and testing cookbooks. At PagerDuty, it meant CI/CD for infrastructure, TDD in operations, and service discovery with Consul. At Uber scale, it meant production engineering, capacity management, incident taxonomy, and ML-assisted operational decisions.
+
+The tools changed. The direction did not.
+
+## Infrastructure as code was the starting point
+
+Chef was the first clear public thread. Talks from FudCon, vodQA, Chef Meetup, ChefConf, and LinuxCon show a progression from configuration management to automated testing and containerized integration workflows.
+
+The argument was simple: infrastructure changes are software changes. They deserve version control, review, tests, feedback loops, and release discipline.
+
+## Testing made operations safer
+
+The testing thread became most explicit in the Agile 2015 talk and experience report on adopting TDD in operations. The work used tools like ChefSpec, Test Kitchen, Serverspec/InSpec, Foodcritic, RSpec, and Jenkins to bring software testing discipline into infrastructure code.
+
+That mattered because untested infrastructure changes are a common source of operational failure. Fast tests make infrastructure safer to change. Slow or absent tests make every change depend on memory and luck.
+
+## Containers made feedback loops faster
+
+The chef-lxc work and LXC talks were about using containers before they became the default deployment vocabulary. The practical goal was fast, repeatable environments for building and testing infrastructure changes.
+
+That was platform engineering before the term became common: create a path where teams can make changes with less local setup, faster feedback, and more confidence.
+
+## Service discovery expanded the boundary
+
+The Consul work at PagerDuty moved the focus from machine configuration to distributed systems coordination. Service discovery, health checking, and distributed configuration sit below the application but above individual hosts. That is a platform layer.
+
+Once systems become service-oriented, the platform has to encode more than deployment. It has to help services find each other, fail safely, and expose enough health signal for operators to act.
+
+## ML-assisted operations is another automation step
+
+At Uber scale, manual capacity planning cannot keep up with hundreds of microservices and variable traffic. Public Uber Engineering Blog work on ML-driven capacity safety and capacity recommendation shows the next step in the same automation arc: use data and prediction to support operational decisions before users see impact.
+
+That is not automation for its own sake. It is automation aimed at better reliability and more efficient infrastructure.
+
+## The pattern
+
+The public career arc is not a set of disconnected tools. It is a series of attempts to make operational systems more explicit, testable, repeatable, and data-driven.
+
+That is the heart of platform engineering for me: make the safe path easier, make the system legible, and turn repeated operational judgment into durable software.
+
+## Public sources
+
+- [System Automation Using Chef](https://ranjib.github.io/about/personal/)
+- [Automated Infrastructure Testing](https://www.slideshare.net/ThoughtWorks/automated-infrastructure-testing-ranjib-dey)
+- [Chef-LXC: Building and Deploying Custom Containers](https://speakerdeck.com/ranjibd/chef-lxc-building-and-deploying-custom-containers)
+- [How to Mock a Mocking Bird](https://speakerdeck.com/ranjibd/how-to-mock-a-mocking-bird-testing-dynamic-infrastructure)
+- [Strategies for adopting TDD in Operations](https://speakerdeck.com/ranjibd/adopting-test-driven-development-in-operations)
+- [Agile Alliance experience report](https://www.agilealliance.org/wp-content/uploads/2015/12/ExperienceReport.2015.Dey_.Strategies_for_adopting_Test_Driven_Development_in_Operations_.pdf)
+- [Consul at PagerDuty](https://speakerdeck.com/ranjibd/consul-at-pagerduty)
+- [Using ML for Microservice Capacity Safety](https://www.uber.com/en-US/blog/capacity-recommendation-engine/)

--- a/content/posts/reef-pi-public-engineering-lessons.md
+++ b/content/posts/reef-pi-public-engineering-lessons.md
@@ -1,0 +1,53 @@
+---
+title: "reef-pi and Public Engineering Lessons"
+date: 2026-05-31T00:00:00-07:00
+draft: false
+---
+
+reef-pi started as an open source Raspberry Pi reef tank controller. The public record now shows something larger: a hobby controller that grew into a small ecosystem of software, documentation, community support, and compatible hardware.
+
+That arc is interesting to me because reef-pi is not only about aquarium automation. It is a compact example of how public engineering systems mature when they need to survive real users, real hardware, and long-lived maintenance.
+
+## Modules make the domain legible
+
+reef-pi turns reef-keeping chores into explicit modules: equipment control, lighting, temperature, auto top-off, pH monitoring, dosing, telemetry, dashboards, and macros. That modular shape matters. It lets a reef keeper reason about the system in the same terms as the aquarium itself.
+
+The public release history shows steady expansion from early beta releases into broader module coverage, then hardware abstraction, operational maturity, dashboards, journal features, and ESP32-based distributed hardware support. The project did not become durable by hiding complexity. It became durable by naming the right boundaries.
+
+## Hardware abstraction was a maintenance decision
+
+A reef controller has to touch messy physical reality: relays, sensors, probes, PWM lights, pumps, and boards from different vendors. The reef-pi HAL and driver repositories make that hardware surface explicit. Drivers for outlets, analog inputs, pH circuits, PWM boards, ESP32 firmware, and related hardware turn the controller into a platform rather than a one-off build.
+
+That is a familiar software lesson in a physical computing setting. A good boundary lets the core system evolve while the edge devices keep changing.
+
+## Documentation created the adoption path
+
+The Adafruit Learn guide series is one of the strongest public artifacts around reef-pi. The seven guides walk through setup, power control, temperature, water level, lighting, pH monitoring, and dosing. They are practical, incremental, and close to the hardware.
+
+That kind of documentation is not decoration. For hardware projects, documentation is part of the product surface. The guide series gives users a reference build path, and it gives the project a shared vocabulary for support.
+
+## Ecosystems need more than code
+
+reef-pi shows several levels of commitment:
+
+- fully DIY wiring and assembly
+- community PCBs and HATs
+- kit-style hardware through Robo-Tank and related listings
+- integrations through the public API
+- support history through GitHub issues and Reef2Reef discussion
+
+That layered ecosystem is a sign that a project has escaped a single maintainer's desk. The software remains central, but the project becomes more useful when others can build around it.
+
+## The broader lesson
+
+Long-lived public systems need clear modules, visible boundaries, written paths, and a community record. Those are the same habits I value in production infrastructure: make the system observable, make the interfaces explicit, document how to operate it, and let real usage shape the roadmap.
+
+reef-pi is a reef tank controller. It is also a reminder that the discipline of reliable systems engineering applies just as well to pumps and probes as it does to services and deployments.
+
+## Public sources
+
+- [reef-pi official site](https://reef-pi.github.io/)
+- [reef-pi GitHub repository](https://github.com/reef-pi/reef-pi)
+- [Adafruit reef-pi guide series](https://learn.adafruit.com/reef-pi-installation-and-configuration)
+- [Make: Automate Your Coral Reef Tank with Raspberry Pi](https://makezine.com/article/technology/raspberry-pi/automate-coral-reef-tank-raspberry-pi/)
+- [Raspberry Pi: Reef-Pi Fish Tank Management System](https://www.raspberrypi.com/news/reef-pi-raspberry-pi-fish-tank-management-system/)

--- a/content/posts/reliability-and-incident-taxonomy.md
+++ b/content/posts/reliability-and-incident-taxonomy.md
@@ -1,0 +1,41 @@
+---
+title: "Reliability Work Starts With Naming Failure"
+date: 2026-05-31T00:00:00-07:00
+draft: false
+---
+
+Reliability engineering often starts with tooling, but the durable work starts earlier: naming what actually fails.
+
+My public talks on resiliency and incident management span from DevopsDays India in 2013 to Uber-focused talks in 2020. The shape changed over time. The early framing was culture, tools, and practices. The later framing was incident taxonomy, data, and large-scale operational learning. The through-line is the same: resilient systems are built deliberately, not wished into existence.
+
+## Taxonomy turns incidents into engineering signal
+
+A taxonomy is useful because it turns a pile of stories into a system of patterns. Without names, every incident feels unique. With names, repeated causes become visible: capacity, dependency failure, deploy risk, operational gaps, incomplete automation, unclear ownership, or missing detection.
+
+That does not make incidents simple. It makes them discussable. It gives engineering teams a way to ask whether they are fixing a one-off issue or paying down a class of risk.
+
+## Incident management is a system, not a meeting
+
+The public material around incident management at Uber emphasizes process at scale: detection, alerting, severity, role clarity, communication, mitigation, postmortems, and follow-up. The important point is that incident management is itself a production system.
+
+That system needs operators, feedback loops, and maintenance. It needs clean handoffs between people diagnosing the issue and people coordinating the response. It needs postmortems that produce engineering work, not just documents.
+
+## Culture and data need each other
+
+The 2013 resiliency framing emphasized culture, tools, and practice. The 2020 taxonomy framing emphasized data. Those are not competing ideas.
+
+A blameless culture without data can become vague. Data without a healthy culture becomes a ranking system for blame. Reliability work needs both: a culture that can look honestly at failure, and data that helps teams see where repeated investment will matter.
+
+## Why this matters now
+
+Modern software systems are too large for heroics to be the operating model. Services have dependencies, regions, queues, caches, deployments, experiments, and traffic patterns. Incidents will happen. The question is whether each one teaches the system something durable.
+
+Naming failure is the first step. It lets teams turn incidents from isolated emergencies into a long-running reliability program.
+
+## Public sources
+
+- [Culturing resiliency with Data: A taxonomy of incidents](https://www.infoq.com/presentations/uber-outages/)
+- How Uber does incident management, Major Incident Management Expo 2020
+- [Using ML for Microservice Capacity Safety](https://www.uber.com/en-US/blog/capacity-recommendation-engine/)
+- [Uber's Failover Architecture: Reconciling Reliability and Efficiency in Hyperscale Microservice Infrastructure](https://www.usenix.org/conference/nsdi26/presentation/bansal)
+- [Attaining Resiliency: Culture, Tools and Practices](https://speakerdeck.com/ranjibd/attaining-resiliency-culture-tools-and-practices)


### PR DESCRIPTION
## Summary
- refresh the public personal/about page from the wiki-generated public publishing pack
- add three public posts on reef-pi engineering lessons, reliability/incident taxonomy, and platform engineering through automation
- add reusable public profile blurbs for outreach and speaker/profile reuse
- refresh the existing `About this website` post to describe the public publishing workflow

## Tracking
- Epic: #6
- Closes #9
- Closes #10
- Closes #11
- Advances #12

## Verification
- `hugo --gc --minify` passed with existing Hugo/theme deprecation warnings
- privacy marker scan over edited content passed: `rg -n "privacy:|sensitive|raw/local|finance|custody|address|SSN|account|Ryan|childcare|eldercare" content/about/personal.md content/about/public-profile.md content/posts` returned no matches

## Notes
- No theme, layout, CSS, config, or asset changes are staged in this PR.
- Existing local dirty generated output and theme submodule state were left unstaged.