### PR TITLE
[codex] Upgrade and fix Pages deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,38 @@
 name: deploy
+
 on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  HUGO_VERSION: "0.85.0"
+
 jobs:
   build:
-    name: build
+    name: build and deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
-      - run: |
-          git clone https://github.com/lxndrblz/anatole.git themes/anatole
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
       - name: Build
-        run: hugo --minify
+        run: hugo --gc --minify
+
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION
## Summary

- Upgrades deploy workflow actions:
  - `actions/checkout@v2` -> `actions/checkout@v6`
  - `peaceiris/actions-hugo@v2` -> `peaceiris/actions-hugo@v3`
  - `peaceiris/actions-gh-pages@v3` -> `peaceiris/actions-gh-pages@v4`
- Aligns deploy with the passing PR build workflow by using recursive submodule checkout and the pinned Anatole submodule.
- Pins deploy Hugo to extended `0.85.0`, matching the passing PR validation workflow.
- Removes the floating `git clone https://github.com/lxndrblz/anatole.git themes/anatole` step.
- Adds manual `workflow_dispatch` for deploy reruns.

## Root Cause

The latest deploy run failed because the old deploy workflow installed latest non-extended Hugo (`0.162.1`) and cloned the floating upstream Anatole theme. The build failed while processing SCSS:

```text
error calling toCSS: no Dart Sass binary found in $PATH
```

The deploy run also warned that `actions/checkout@v2` and `peaceiris/actions-hugo@v2` use deprecated Node.js 20 actions.

## Tracking

Closes #20.

## Validation

- Inspected failing deploy run: https://github.com/ranjib/ranjib.github.io/actions/runs/26718313714
- `git diff --check` passes.
- `git submodule update --init --recursive` completed in a fresh worktree.
- Local `hugo --gc --minify` could not complete in this environment because the local snap-packaged Hugo failed before loading the site:

```text
ERROR failed to load modules: failed to apply mounts for project: failed to open dir "/var/lib/snapd/void": "open /var/lib/snapd/void: permission denied"
```

Hosted PR validation should confirm the build path before merge; deploy validation happens on the post-merge push to `master`.
