### PR TITLE
feat: implement issue #22 deferred design system items

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -200,6 +200,61 @@ img, svg { max-width: 100%; display: block; }
 .post-body th, .post-body td { padding: var(--s-2) var(--s-3); border: 1px solid var(--hairline); text-align: left; }
 .post-body th { background: var(--surface-alt); font-family: var(--font-sans); font-weight: 600; }
 
+/* ---- Dark mode toggle ---- */
+.theme-toggle {
+  background: none;
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-md);
+  padding: var(--s-1) var(--s-2);
+  color: var(--text-meta);
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  line-height: 1;
+  transition: color var(--dur-fast) var(--ease-out), border-color var(--dur-fast) var(--ease-out);
+}
+.theme-toggle:hover { color: var(--link); border-color: var(--link); }
+
+/* ---- Responsive images ---- */
+.post-body figure { margin-inline: 0; margin-block: var(--s-6); }
+.post-body figure img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--r-md);
+  display: block;
+}
+.post-body figcaption {
+  font-family: var(--font-sans);
+  font-size: var(--fs-sm);
+  color: var(--text-meta);
+  margin-top: var(--s-2);
+  text-align: center;
+}
+
+/* ---- Syntax highlighting (Chroma, noClasses=false) ---- */
+.chroma { background: var(--syn-bg); border-radius: var(--r-md); padding: var(--s-5); overflow-x: auto; }
+.chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+.chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: 100%; overflow: auto; display: block; }
+.chroma .lnt { color: var(--text-meta); margin-inline-end: var(--s-4); user-select: none; }
+
+/* Comments */
+.chroma .c, .chroma .ch, .chroma .cm, .chroma .c1, .chroma .cs, .chroma .cp, .chroma .cpf { color: var(--syn-comment); font-style: italic; }
+/* Keywords */
+.chroma .k, .chroma .kc, .chroma .kd, .chroma .kn, .chroma .kp, .chroma .kr, .chroma .kt { color: var(--syn-keyword); font-weight: 500; }
+/* Strings */
+.chroma .s, .chroma .sa, .chroma .sb, .chroma .sc, .chroma .dl, .chroma .sd, .chroma .s2, .chroma .se,
+.chroma .sh, .chroma .si, .chroma .sx, .chroma .sr, .chroma .s1, .chroma .ss { color: var(--syn-string); }
+/* Numbers */
+.chroma .m, .chroma .mb, .chroma .mf, .chroma .mh, .chroma .mi, .chroma .il, .chroma .mo { color: var(--syn-number); }
+/* Operators */
+.chroma .o, .chroma .ow { color: var(--syn-operator); }
+/* Names: functions, builtins */
+.chroma .nf, .chroma .nc, .chroma .nd, .chroma .ni, .chroma .ne, .chroma .nv { color: var(--syn-name); }
+.chroma .nb, .chroma .bp { color: var(--syn-builtin); }
+/* Default text */
+.chroma .nt, .chroma .nn, .chroma .n { color: var(--text); }
+/* Error */
+.chroma .err { color: #c0392b; }
+
 /* ---- Utilities ---- */
 .sr-only {
   position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,16 @@
 baseURL = 'http://ranjib.com'
 defaultContentLanguage = 'en'
 
+[markup]
+  [markup.highlight]
+    noClasses = false
+    codeFences = true
+    lineNos = false
+    tabWidth = 2
+
+  [markup.goldmark.renderer]
+    unsafe = false
+
 [params]
 profilePicture = 'images/profile.jpeg'
 title = 'Personal Website of Ranjib Dey'

--- a/design-system/STRATEGY.md
+++ b/design-system/STRATEGY.md
@@ -1,0 +1,72 @@
+# Design System Strategy — ranjib.dev
+
+## §1 Purpose
+
+This document governs the design system for ranjib.dev. It defines the workflow, constraints, and decision-making authority for all visual changes.
+
+## §2 Design token hierarchy
+
+`design-system/tokens.css` is the **single source of truth** for every visual value. Two categories:
+
+- **Primitive tokens** — raw palette values (e.g. `--ink-12`, `--accent-terra`). Defined once, never changed except for palette refresh.
+- **Semantic tokens** — context-specific values that map to primitives (e.g. `--text`, `--bg`, `--link`). Light and dark modes both live in `tokens.css`.
+
+**Rule:** `assets/css/main.css` may reference only semantic tokens. No primitive token should appear outside `tokens.css`.
+
+## §3 File roles
+
+| File | Role |
+|------|------|
+| `design-system/tokens.css` | All CSS custom properties. Inlined per page via `os.ReadFile`. |
+| `design-system/STRATEGY.md` | This file. Governance and decisions. |
+| `design-system/styleguide.html` | Static HTML preview of all components. Reference for new components. |
+| `design-system/templates/*.html` | Static HTML page mockups (home, post, listing, about). |
+| `assets/css/main.css` | Layout and component CSS. References tokens only. |
+| `layouts/partials/` | Hugo templates. Must use same class names as styleguide. |
+
+## §4 Two-tool workflow
+
+When designing a new component:
+
+1. **Tool 1 — Static design:** Edit `design-system/styleguide.html` and/or a template in `design-system/templates/`. Use only token variables. Get visual sign-off before writing Hugo templates.
+2. **Tool 2 — Hugo binding:** Copy HTML from the styleguide into the relevant partial. Wire up Hugo variables.
+
+Never write Hugo template code first. Always design in static HTML.
+
+## §5 Adding tokens
+
+1. Add the primitive to `:root` in `tokens.css`.
+2. Add a semantic alias in both `:root, [data-theme="light"]` and `[data-theme="dark"]` blocks.
+3. Document the intended usage in a comment.
+4. Update `design-system/styleguide.html` with a swatch or example.
+
+## §6 Dark mode
+
+Dark mode is driven by `[data-theme="dark"]` on the `<html>` element. The toggle is in `layouts/partials/site-header.html`. User preference is persisted to `localStorage`.
+
+Tokens that differ between light and dark are declared in both blocks in `tokens.css`. If a token is the same in both modes, declare it only in `:root`.
+
+## §7 CLAUDE.md
+
+`CLAUDE.md` at the repo root summarises these rules for agentic sessions.
+
+## §8 Deferred items (tracked in GitHub issue #22)
+
+- Code syntax highlighting (Chroma theme using `--syn-*` tokens)
+- Responsive image pipeline (WebP + fallback, lazy loading)
+- Search (Pagefind, post-build)
+- RSS (Hugo default is live; custom template deferred)
+- Comments (stance: none)
+- Dark/light mode toggle (JS + `data-theme`)
+- `design-system/templates/` HTML page mockups
+
+## §9 Quality bar
+
+Before any PR touching visual code:
+
+- No hardcoded hex, rgb, or px values outside `tokens.css`
+- All new tokens added to `tokens.css` first
+- `hugo build` exits 0 with no warnings
+- Checked at 320px, 768px, 1200px
+- Focus rings visible on all interactive elements
+- `design-system/styleguide.html` updated to reflect any new components

--- a/design-system/styleguide.html
+++ b/design-system/styleguide.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ranjib.dev — Design System Styleguide</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Source+Serif+4:opsz,wght@8..60,300;8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet" />
+  <style id="tokens">/* tokens injected below for standalone preview */</style>
+  <script>
+    fetch('tokens.css').then(r => r.text()).then(css => {
+      document.getElementById('tokens').textContent = css;
+    });
+  </script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html { -webkit-font-smoothing: antialiased; }
+    body {
+      margin: 0;
+      font-family: var(--font-serif);
+      font-size: var(--fs-md);
+      line-height: var(--lh-prose);
+      color: var(--text);
+      background: var(--bg);
+    }
+    .sg-container { max-width: 1080px; margin: 0 auto; padding: 3rem 1.5rem; }
+    .sg-section { margin-bottom: 4rem; }
+    .sg-section-title {
+      font-family: var(--font-sans);
+      font-size: var(--fs-sm);
+      font-weight: 600;
+      letter-spacing: var(--tr-wide);
+      text-transform: uppercase;
+      color: var(--text-meta);
+      border-bottom: 1px solid var(--hairline);
+      padding-bottom: var(--s-3);
+      margin-bottom: var(--s-6);
+    }
+
+    /* Swatches */
+    .swatch-grid { display: flex; flex-wrap: wrap; gap: var(--s-3); }
+    .swatch {
+      width: 80px;
+      border-radius: var(--r-md);
+      overflow: hidden;
+      font-family: var(--font-sans);
+      font-size: var(--fs-xs);
+    }
+    .swatch-color { height: 48px; }
+    .swatch-label { background: var(--surface-alt); padding: var(--s-1) var(--s-2); color: var(--text-muted); }
+
+    /* Type scale */
+    .type-row { margin-bottom: var(--s-4); display: flex; align-items: baseline; gap: var(--s-5); }
+    .type-label { font-family: var(--font-sans); font-size: var(--fs-xs); color: var(--text-meta); width: 90px; flex-shrink: 0; }
+
+    /* Components */
+    .site-header { border-bottom: 1px solid var(--hairline); padding-block: var(--s-4); }
+    .site-header-inner { display: flex; align-items: center; justify-content: space-between; }
+    .site-wordmark { font-family: var(--font-sans); font-size: var(--fs-base); font-weight: 600; color: var(--text); text-decoration: none; letter-spacing: var(--tr-tight); }
+    .site-nav { display: flex; gap: var(--s-5); list-style: none; margin: 0; padding: 0; }
+    .site-nav a { font-family: var(--font-sans); font-size: var(--fs-sm); font-weight: 500; color: var(--text-muted); text-decoration: none; letter-spacing: var(--tr-wide); text-transform: uppercase; }
+    .site-nav a.active { color: var(--link); }
+
+    .post-card { padding-block: var(--s-5); border-bottom: 1px solid var(--hairline); }
+    .post-card-title { font-family: var(--font-serif); font-size: var(--fs-xl); font-weight: 500; line-height: var(--lh-snug); letter-spacing: var(--tr-tight); margin: 0 0 var(--s-2); }
+    .post-card-title a { color: var(--text); text-decoration: none; }
+    .post-card-meta { font-family: var(--font-sans); font-size: var(--fs-sm); color: var(--text-meta); margin: 0 0 var(--s-3); }
+    .post-card-summary { font-size: var(--fs-base); color: var(--text-muted); margin: 0; }
+
+    .site-footer { border-top: 1px solid var(--hairline); padding-block: var(--s-6); font-family: var(--font-sans); font-size: var(--fs-sm); color: var(--text-meta); text-align: center; }
+
+    .prose-sample p { line-height: var(--lh-prose); max-width: var(--measure-prose); }
+    .prose-sample code { font-family: var(--font-mono); font-size: var(--fs-sm); background: var(--surface-alt); padding: 0.1em 0.3em; border-radius: var(--r-sm); }
+    .prose-sample pre { background: var(--surface-alt); padding: var(--s-5); border-radius: var(--r-md); overflow-x: auto; }
+    .prose-sample pre code { background: none; padding: 0; }
+    .prose-sample blockquote { margin-inline: 0; padding-inline-start: var(--s-5); border-left: 3px solid var(--hairline); color: var(--text-muted); font-style: italic; }
+
+    /* Dark mode toggle */
+    .theme-toggle {
+      background: none;
+      border: 1px solid var(--hairline);
+      border-radius: var(--r-md);
+      padding: var(--s-1) var(--s-3);
+      font-family: var(--font-sans);
+      font-size: var(--fs-xs);
+      color: var(--text-meta);
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+<div class="sg-container">
+
+  <h1 style="font-family:var(--font-sans);font-size:var(--fs-2xl);margin-bottom:var(--s-2)">ranjib.dev Styleguide</h1>
+  <p style="font-family:var(--font-sans);color:var(--text-meta);margin-bottom:var(--s-8)">Reference for all design tokens and components. Do not build before designing here first.</p>
+  <button class="theme-toggle" onclick="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'">Toggle dark mode</button>
+
+  <!-- COLOR TOKENS -->
+  <section class="sg-section" style="margin-top:var(--s-8)">
+    <div class="sg-section-title">Color — Ink Palette</div>
+    <div class="swatch-grid">
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-1)"></div><div class="swatch-label">--ink-1</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-2)"></div><div class="swatch-label">--ink-2</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-3)"></div><div class="swatch-label">--ink-3</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-4)"></div><div class="swatch-label">--ink-4</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-5)"></div><div class="swatch-label">--ink-5</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-6)"></div><div class="swatch-label">--ink-6</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-7)"></div><div class="swatch-label">--ink-7</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-8)"></div><div class="swatch-label">--ink-8</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-9)"></div><div class="swatch-label">--ink-9</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-10)"></div><div class="swatch-label">--ink-10</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-11)"></div><div class="swatch-label">--ink-11</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--ink-12)"></div><div class="swatch-label">--ink-12</div></div>
+    </div>
+    <div class="swatch-grid" style="margin-top:var(--s-4)">
+      <div class="swatch"><div class="swatch-color" style="background:var(--accent-terra)"></div><div class="swatch-label">--accent-terra</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--accent-terra-dim)"></div><div class="swatch-label">--accent-terra-dim</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--accent-terra-lit)"></div><div class="swatch-label">--accent-terra-lit</div></div>
+    </div>
+  </section>
+
+  <section class="sg-section">
+    <div class="sg-section-title">Color — Semantic Tokens</div>
+    <div class="swatch-grid">
+      <div class="swatch"><div class="swatch-color" style="background:var(--bg);border:1px solid var(--hairline)"></div><div class="swatch-label">--bg</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--surface-alt)"></div><div class="swatch-label">--surface-alt</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--text)"></div><div class="swatch-label">--text</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--text-muted)"></div><div class="swatch-label">--text-muted</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--text-meta)"></div><div class="swatch-label">--text-meta</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--link)"></div><div class="swatch-label">--link</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--link-hover)"></div><div class="swatch-label">--link-hover</div></div>
+      <div class="swatch"><div class="swatch-color" style="background:var(--hairline)"></div><div class="swatch-label">--hairline</div></div>
+    </div>
+  </section>
+
+  <!-- TYPE SCALE -->
+  <section class="sg-section">
+    <div class="sg-section-title">Type Scale — Source Serif 4</div>
+    <div class="type-row"><span class="type-label">--fs-4xl / 2.25rem</span><span style="font-size:var(--fs-4xl);font-family:var(--font-serif);line-height:1.1;letter-spacing:var(--tr-tight)">Platform Engineering</span></div>
+    <div class="type-row"><span class="type-label">--fs-3xl / 1.875rem</span><span style="font-size:var(--fs-3xl);font-family:var(--font-serif);line-height:1.15;letter-spacing:var(--tr-tight)">Platform Engineering</span></div>
+    <div class="type-row"><span class="type-label">--fs-2xl / 1.5rem</span><span style="font-size:var(--fs-2xl);font-family:var(--font-serif);line-height:1.25;letter-spacing:var(--tr-tight)">Platform Engineering</span></div>
+    <div class="type-row"><span class="type-label">--fs-xl / 1.25rem</span><span style="font-size:var(--fs-xl);font-family:var(--font-serif)">Platform Engineering</span></div>
+    <div class="type-row"><span class="type-label">--fs-md / 1.0625rem</span><span style="font-size:var(--fs-md);font-family:var(--font-serif)">Platform Engineering — body copy at 17px</span></div>
+    <div class="type-row"><span class="type-label">--fs-base / 1rem</span><span style="font-size:var(--fs-base);font-family:var(--font-sans)">Inter for UI / nav — 16px</span></div>
+    <div class="type-row"><span class="type-label">--fs-sm / 0.875rem</span><span style="font-size:var(--fs-sm);font-family:var(--font-sans);color:var(--text-meta)">Meta: Jan 1, 2026 · 4 min read</span></div>
+    <div class="type-row"><span class="type-label">--font-mono</span><span style="font-size:var(--fs-sm);font-family:var(--font-mono)">const answer = 42; // JetBrains Mono</span></div>
+  </section>
+
+  <!-- SITE HEADER -->
+  <section class="sg-section">
+    <div class="sg-section-title">Component — Site Header</div>
+    <header class="site-header">
+      <div class="site-header-inner">
+        <a href="#" class="site-wordmark">Personal Website of Ranjib Dey</a>
+        <nav>
+          <ul class="site-nav">
+            <li><a href="#" class="active">Home</a></li>
+            <li><a href="#">Blogs</a></li>
+            <li><a href="#">About</a></li>
+            <li><button class="theme-toggle" onclick="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'">◑</button></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  </section>
+
+  <!-- POST CARD -->
+  <section class="sg-section">
+    <div class="sg-section-title">Component — Post Card</div>
+    <article class="post-card">
+      <h2 class="post-card-title"><a href="#">Platform Engineering Through Automation</a></h2>
+      <p class="post-card-meta"><time>January 15, 2026</time> · 6 min read</p>
+      <p class="post-card-summary">Lessons learned building self-service infrastructure platforms and the hidden costs of over-automation.</p>
+    </article>
+    <article class="post-card">
+      <h2 class="post-card-title"><a href="#">Reef-Pi: Public Engineering Lessons</a></h2>
+      <p class="post-card-meta"><time>October 3, 2025</time> · 4 min read</p>
+      <p class="post-card-summary">What open-source reef controller development taught me about community, hardware, and software reliability.</p>
+    </article>
+  </section>
+
+  <!-- PROSE -->
+  <section class="sg-section">
+    <div class="sg-section-title">Component — Prose / Post Body</div>
+    <div class="prose-sample">
+      <p>Body text at <code>--fs-md</code> (17px) with <code>--lh-prose</code> (1.72). The measure is constrained to <code>--measure-prose</code> (68ch) for optimal reading comfort. Links are <a href="#" style="color:var(--link)">terra-accented and underlined</a>.</p>
+      <blockquote><p>A blockquote with a terra-hairline left border and muted, italicised text. Good for callouts and references.</p></blockquote>
+      <p>Inline <code>code</code> uses <code>--surface-alt</code> background and JetBrains Mono.</p>
+      <pre><code>// Fenced code block
+func main() {
+    fmt.Println("hello, ranjib.dev")
+}</code></pre>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <section class="sg-section">
+    <div class="sg-section-title">Component — Site Footer</div>
+    <footer class="site-footer">
+      <p>© 2026 Ranjib Dey</p>
+    </footer>
+  </section>
+
+</div>
+</body>
+</html>

--- a/design-system/templates/about.html
+++ b/design-system/templates/about.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About — Personal Website of Ranjib Dey</title>
+  <style>/* tokens.css + main.css */</style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-wordmark">Personal Website of Ranjib Dey</a>
+      <nav aria-label="Site navigation">
+        <ul class="site-nav">
+          <li><a href="/">Home</a></li>
+          <li><a href="/posts/">Blogs</a></li>
+          <li><a href="/about/" aria-current="page">About</a></li>
+          <li><button class="theme-toggle" aria-label="Toggle dark mode">◑</button></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main site-container">
+    <div class="page-header">
+      <h1 class="page-title">About</h1>
+    </div>
+
+    <div class="post-list">
+      <!-- About section lists its child pages as cards, same as any section listing -->
+      <article class="post-card">
+        <h2 class="post-card-title"><a href="/about/public-profile/">Public Profile</a></h2>
+        <p class="post-card-summary">Professional background and open-source work.</p>
+      </article>
+      <article class="post-card">
+        <h2 class="post-card-title"><a href="/about/personal/">Personal</a></h2>
+        <p class="post-card-summary">Hobbies, reef keeping, and life outside engineering.</p>
+      </article>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="site-container"><p>© 2026 Ranjib Dey</p></div>
+  </footer>
+</body>
+</html>

--- a/design-system/templates/home.html
+++ b/design-system/templates/home.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Personal Website of Ranjib Dey</title>
+  <!-- In Hugo: tokens inlined via os.ReadFile, main.css via resources.Get|fingerprint -->
+  <style>/* tokens.css + main.css would be here */</style>
+</head>
+<body>
+  <!-- SITE HEADER -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-wordmark">Personal Website of Ranjib Dey</a>
+      <nav aria-label="Site navigation">
+        <ul class="site-nav">
+          <li><a href="/" aria-current="page">Home</a></li>
+          <li><a href="/posts/">Blogs</a></li>
+          <li><a href="/about/">About</a></li>
+          <li>
+            <button class="theme-toggle" aria-label="Toggle dark mode">◑</button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <!-- MAIN -->
+  <main class="site-main site-container">
+    <section class="home-intro">
+      <h1 class="page-title">Personal Website of Ranjib Dey</h1>
+      <p class="home-lead">Platform engineer, open-source author, reef keeper. Writing about infrastructure, reliability, and building things in public.</p>
+    </section>
+
+    <div class="post-list">
+      <!-- post-card repeated for each of the 5 most recent posts -->
+      <article class="post-card">
+        <h2 class="post-card-title"><a href="/posts/platform-engineering/">Platform Engineering Through Automation</a></h2>
+        <p class="post-card-meta"><time datetime="2026-01-15">January 15, 2026</time> · 6 min read</p>
+        <p class="post-card-summary">Lessons learned building self-service infrastructure platforms.</p>
+      </article>
+      <article class="post-card">
+        <h2 class="post-card-title"><a href="/posts/reef-pi/">Reef-Pi: Public Engineering Lessons</a></h2>
+        <p class="post-card-meta"><time datetime="2025-10-03">October 3, 2025</time> · 4 min read</p>
+        <p class="post-card-summary">What open-source reef controller development taught me.</p>
+      </article>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <footer class="site-footer">
+    <div class="site-container">
+      <p>© 2026 Ranjib Dey</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/design-system/templates/listing.html
+++ b/design-system/templates/listing.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blogs — Personal Website of Ranjib Dey</title>
+  <style>/* tokens.css + main.css */</style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-wordmark">Personal Website of Ranjib Dey</a>
+      <nav aria-label="Site navigation">
+        <ul class="site-nav">
+          <li><a href="/">Home</a></li>
+          <li><a href="/posts/" aria-current="page">Blogs</a></li>
+          <li><a href="/about/">About</a></li>
+          <li><button class="theme-toggle" aria-label="Toggle dark mode">◑</button></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main site-container">
+    <div class="page-header">
+      <h1 class="page-title">Blogs</h1>
+    </div>
+
+    <div class="post-list">
+      <article class="post-card">
+        <h2 class="post-card-title"><a href="/posts/platform-engineering/">Platform Engineering Through Automation</a></h2>
+        <p class="post-card-meta"><time datetime="2026-01-15">January 15, 2026</time> · 6 min read</p>
+        <p class="post-card-summary">Lessons learned building self-service infrastructure platforms and the hidden costs of over-automation.</p>
+      </article>
+      <article class="post-card">
+        <h2 class="post-card-title"><a href="/posts/reef-pi/">Reef-Pi: Public Engineering Lessons</a></h2>
+        <p class="post-card-meta"><time datetime="2025-10-03">October 3, 2025</time> · 4 min read</p>
+        <p class="post-card-summary">What open-source reef controller development taught me about community, hardware, and software reliability.</p>
+      </article>
+      <article class="post-card">
+        <h2 class="post-card-title"><a href="/posts/reliability/">Reliability and Incident Taxonomy</a></h2>
+        <p class="post-card-meta"><time datetime="2025-06-10">June 10, 2025</time> · 5 min read</p>
+        <p class="post-card-summary">A framework for classifying incidents and deriving meaningful signals from noisy on-call rotations.</p>
+      </article>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="site-container"><p>© 2026 Ranjib Dey</p></div>
+  </footer>
+</body>
+</html>

--- a/design-system/templates/post.html
+++ b/design-system/templates/post.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Platform Engineering Through Automation — Personal Website of Ranjib Dey</title>
+  <style>/* tokens.css + main.css */</style>
+</head>
+<body>
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-wordmark">Personal Website of Ranjib Dey</a>
+      <nav aria-label="Site navigation">
+        <ul class="site-nav">
+          <li><a href="/">Home</a></li>
+          <li><a href="/posts/" aria-current="page">Blogs</a></li>
+          <li><a href="/about/">About</a></li>
+          <li><button class="theme-toggle" aria-label="Toggle dark mode">◑</button></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="site-main site-container">
+    <article>
+      <header class="post-header">
+        <h1 class="post-title">Platform Engineering Through Automation</h1>
+        <p class="post-meta">
+          <time datetime="2026-01-15">January 15, 2026</time>
+          <span>·</span>
+          <span>6 min read</span>
+        </p>
+      </header>
+
+      <div class="post-body">
+        <p>Opening paragraph. The prose container is constrained to <code>--measure-prose</code> (68ch).</p>
+
+        <h2>A Second-Level Heading</h2>
+        <p>Body copy. Links are <a href="#">terra-accented</a>. Inline <code>code</code> uses surface-alt background.</p>
+
+        <pre><code class="language-go">func main() {
+    fmt.Println("hello, ranjib.dev")
+}</code></pre>
+
+        <blockquote>
+          <p>A blockquote with terra-hairline border-left and muted italic text.</p>
+        </blockquote>
+
+        <h3>A Third-Level Heading</h3>
+        <p>More prose content. Tables, lists, and images follow the same token system.</p>
+
+        <table>
+          <thead>
+            <tr><th>Column A</th><th>Column B</th><th>Column C</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Value 1</td><td>Value 2</td><td>Value 3</td></tr>
+            <tr><td>Value 4</td><td>Value 5</td><td>Value 6</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </article>
+  </main>
+
+  <footer class="site-footer">
+    <div class="site-container"><p>© 2026 Ranjib Dey</p></div>
+  </footer>
+</body>
+</html>

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,0 +1,140 @@
+/* ============================================================
+   ranjib.dev — Design Tokens
+   Single source of truth for all visual values.
+   Inlined into every page <head> via os.ReadFile in head.html.
+   ============================================================ */
+
+/* ---- Primitive palette ---- */
+:root {
+  /* Ink scale — warm dark neutrals */
+  --ink-1:  #f8f4f0;
+  --ink-2:  #ede5dd;
+  --ink-3:  #e0d5cc;
+  --ink-4:  #c9bbaf;
+  --ink-5:  #b09f91;
+  --ink-6:  #958274;
+  --ink-7:  #7b6759;
+  --ink-8:  #624e41;
+  --ink-9:  #4c3a2f;
+  --ink-10: #382a21;
+  --ink-11: #251b14;
+  --ink-12: #150d07;
+
+  /* Terra accent — earthy burnt orange */
+  --accent-terra:     #9e4a22;
+  --accent-terra-dim: #7a3518;
+  --accent-terra-lit: #c0622f;
+}
+
+/* ---- Semantic tokens — light mode (default) ---- */
+:root,
+[data-theme="light"] {
+  --bg:           var(--ink-1);
+  --text:         var(--ink-12);
+  --text-muted:   var(--ink-9);
+  --text-meta:    var(--ink-7);
+  --link:         var(--accent-terra);
+  --link-hover:   var(--accent-terra-dim);
+  --hairline:     var(--ink-3);
+  --surface-alt:  var(--ink-2);
+  --selection:    #f2d3c2;
+
+  /* Syntax highlighting */
+  --syn-bg:       var(--ink-2);
+  --syn-comment:  var(--ink-7);
+  --syn-keyword:  var(--accent-terra);
+  --syn-string:   #3d7a43;
+  --syn-number:   #1a5fa8;
+  --syn-operator: var(--ink-8);
+  --syn-name:     var(--ink-11);
+  --syn-builtin:  #6b3fa0;
+}
+
+/* ---- Semantic tokens — dark mode ---- */
+[data-theme="dark"] {
+  --bg:           var(--ink-12);
+  --text:         var(--ink-1);
+  --text-muted:   var(--ink-5);
+  --text-meta:    var(--ink-6);
+  --link:         #d4733e;
+  --link-hover:   #e8915a;
+  --hairline:     var(--ink-10);
+  --surface-alt:  var(--ink-11);
+  --selection:    #5a2e18;
+
+  /* Syntax highlighting */
+  --syn-bg:       var(--ink-11);
+  --syn-comment:  var(--ink-6);
+  --syn-keyword:  #e07a45;
+  --syn-string:   #6dbf73;
+  --syn-number:   #6ab0f5;
+  --syn-operator: var(--ink-4);
+  --syn-name:     var(--ink-2);
+  --syn-builtin:  #b48ae8;
+}
+
+/* ---- Typography ---- */
+:root {
+  --font-serif: 'Source Serif 4', Georgia, 'Times New Roman', serif;
+  --font-sans:  'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono:  'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* Font sizes — fluid-ish but simple */
+  --fs-xs:   0.75rem;    /* 12px */
+  --fs-sm:   0.875rem;   /* 14px */
+  --fs-base: 1rem;       /* 16px */
+  --fs-md:   1.0625rem;  /* 17px — body */
+  --fs-lg:   1.125rem;   /* 18px */
+  --fs-xl:   1.25rem;    /* 20px */
+  --fs-2xl:  1.5rem;     /* 24px */
+  --fs-3xl:  1.875rem;   /* 30px */
+  --fs-4xl:  2.25rem;    /* 36px */
+
+  /* Line heights */
+  --lh-tight:  1.15;
+  --lh-snug:   1.35;
+  --lh-normal: 1.55;
+  --lh-prose:  1.72;
+
+  /* Letter spacing */
+  --tr-tight: -0.022em;
+  --tr-wide:   0.06em;
+  --tr-mono:   0;
+}
+
+/* ---- Spacing (4-point base scale) ---- */
+:root {
+  --s-1:  0.25rem;   /* 4px */
+  --s-2:  0.5rem;    /* 8px */
+  --s-3:  0.75rem;   /* 12px */
+  --s-4:  1rem;      /* 16px */
+  --s-5:  1.25rem;   /* 20px */
+  --s-6:  1.5rem;    /* 24px */
+  --s-7:  2rem;      /* 32px */
+  --s-8:  3rem;      /* 48px */
+  --s-9:  4rem;      /* 64px */
+  --s-10: 6rem;      /* 96px */
+}
+
+/* ---- Layout ---- */
+:root {
+  --content-max:   1080px;
+  --gutter:        1.5rem;
+  --measure-prose: 68ch;
+}
+
+/* ---- Border radius ---- */
+:root {
+  --r-sm: 3px;
+  --r-md: 6px;
+  --r-lg: 12px;
+  --r-xl: 20px;
+}
+
+/* ---- Transitions ---- */
+:root {
+  --dur-fast:   150ms;
+  --dur-normal: 250ms;
+  --ease-out:   cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in:    cubic-bezier(0.7, 0, 0.84, 0);
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,14 @@
 <html lang="{{ .Site.Language.Lang }}" data-theme="light">
 <head>
   {{ partial "head.html" . }}
+  <script>
+    (function(){
+      var t = localStorage.getItem('theme');
+      if (t === 'dark' || (!t && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
 </head>
 <body>
   {{ partial "site-header.html" . }}
@@ -9,5 +17,16 @@
     {{ block "main" . }}{{ end }}
   </main>
   {{ partial "site-footer.html" . }}
+  <script>
+    (function(){
+      var btn = document.getElementById('theme-toggle');
+      if (!btn) return;
+      btn.addEventListener('click', function(){
+        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        localStorage.setItem('theme', next);
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -8,6 +8,9 @@
           <a href="{{ .URL }}"{{ if $.Page.IsMenuCurrent "main" . }} aria-current="page"{{ end }}>{{ .Name }}</a>
         </li>
         {{ end }}
+        <li>
+          <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">◑</button>
+        </li>
       </ul>
     </nav>
   </div>

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,0 +1,44 @@
+{{/* Responsive image shortcode
+   Usage: {{< img src="photo.jpg" alt="Description" caption="Optional caption" >}}
+   - src: path relative to the page bundle or /static/
+   - alt: required for accessibility
+   - caption: optional figcaption text
+*/}}
+{{ $src := .Get "src" }}
+{{ $alt := .Get "alt" | default "" }}
+{{ $caption := .Get "caption" }}
+
+{{ $img := .Page.Resources.GetMatch $src }}
+{{ if not $img }}
+  {{ $img = resources.Get $src }}
+{{ end }}
+
+{{ if $img }}
+  {{ $w1x := $img.Resize "800x webp" }}
+  {{ $w2x := $img.Resize "1600x webp" }}
+  {{ $fallback := $img.Resize "800x" }}
+  <figure>
+    <picture>
+      <source
+        type="image/webp"
+        srcset="{{ $w1x.RelPermalink }} 800w, {{ $w2x.RelPermalink }} 1600w"
+        sizes="(max-width: 800px) 100vw, 800px"
+      />
+      <img
+        src="{{ $fallback.RelPermalink }}"
+        alt="{{ $alt }}"
+        width="{{ $fallback.Width }}"
+        height="{{ $fallback.Height }}"
+        loading="lazy"
+        decoding="async"
+      />
+    </picture>
+    {{ with $caption }}<figcaption>{{ . }}</figcaption>{{ end }}
+  </figure>
+{{ else }}
+  {{/* Fallback for images in /static/ that aren't page-bundle resources */}}
+  <figure>
+    <img src="{{ $src | relURL }}" alt="{{ $alt }}" loading="lazy" decoding="async" />
+    {{ with $caption }}<figcaption>{{ . }}</figcaption>{{ end }}
+  </figure>
+{{ end }}


### PR DESCRIPTION
Closes #22.

## Summary

- **`design-system/tokens.css`** — CSS custom properties were missing, causing the `<style>` block to be empty on every page. Adds the full ink palette, terra accent, semantic light/dark tokens, spacing scale, typography, and transition vars.
- **`design-system/STRATEGY.md`** — governance doc referenced by CLAUDE.md
- **`design-system/styleguide.html`** — standalone HTML component preview with a live dark-mode toggle; loads tokens.css via `fetch` for local use
- **`design-system/templates/`** — static HTML page mockups for home, post, listing, and about pages, for use in future design sessions
- **Dark/light mode toggle** — inline JS in `baseof.html` reads `localStorage` + `prefers-color-scheme` before first paint (no FOUC); toggle button in site header persists choice
- **Chroma syntax highlighting** — `markup.highlight.noClasses = false` in `config.toml`; `.chroma` CSS rules in `main.css` using `--syn-*` tokens (light + dark)
- **Responsive image shortcode** — `{{< img src="..." alt="..." >}}` generates WebP + fallback `<picture>` with lazy loading via Hugo's image processing pipeline

## Skipped items from #22

| Item | Reason |
|------|--------|
| Search (Pagefind) | Requires post-build CI step; deferred |
| Comments (Giscus) | Current stance: none |
| RSS custom template | Hugo default feed already live |

## Test plan

- [ ] `hugo build` exits 0 with no warnings
- [ ] `public/index.html` `<style>` block contains `--accent-terra` and `--ink-` tokens
- [ ] Dark mode toggle button visible in header
- [ ] Clicking toggle changes `data-theme` attribute on `<html>`
- [ ] Preference persisted across page reload (localStorage)
- [ ] Code fences in posts render with `.chroma` class structure
- [ ] `{{< img >}}` shortcode renders `<picture>` with WebP source for page-bundle images

🤖 Generated with [Claude Code](https://claude.com/claude-code)