### PR TITLE
fix: bump Hugo to 0.162.1 and repair CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  HUGO_VERSION: "0.85.0"
+  HUGO_VERSION: "0.162.1"
 
 jobs:
   hugo:
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  HUGO_VERSION: "0.85.0"
+  HUGO_VERSION: "0.162.1"
 
 jobs:
   build:
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3


### PR DESCRIPTION
## Summary

- **Hugo 0.85.0 → 0.162.1** — the site uses `os.ReadFile` in `head.html` (requires Hugo ≥0.91) and other post-0.85 features. The old pin would fail the build on CI.
- **`actions/checkout@v6` → `@v4`** — v6 does not exist; GitHub would fall back to an unexpected version.
- **Remove `submodules: recursive`** — no submodules since the `nuke_theme` PR removed `themes/anatole`.

## Test plan

- [ ] Build workflow passes on a PR
- [ ] Deploy workflow produces a `public/` with token-inlined HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)