### PR TITLE
fix: set baseURL to ranjib.github.io, repair CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  HUGO_VERSION: "0.85.0"
+  HUGO_VERSION: "0.162.1"
 
 jobs:
   hugo:
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  HUGO_VERSION: "0.85.0"
+  HUGO_VERSION: "0.162.1"
 
 jobs:
   build:
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://ranjib.com'
+baseURL = 'https://ranjib.github.io'
 defaultContentLanguage = 'en'
 
 [markup]


### PR DESCRIPTION
## Summary

- **`baseURL = 'http://ranjib.com'` → `'https://ranjib.github.io'`** — Hugo uses baseURL to build all absolute hrefs (wordmark, RSS link, permalinks). The old value sent every link to the wrong domain.
- Folds in the CI fixes from the unmerged PR #25: Hugo 0.85.0 → 0.162.1, `checkout@v6` → `@v4`, remove `submodules: recursive`.

## Verification

After the fix, `hugo build` output contains:
```
href="https://ranjib.github.io/"
href="https://ranjib.github.io/posts/..."
href="https://ranjib.github.io/index.xml"
```

## Test plan

- [ ] All nav and post links resolve under `ranjib.github.io`
- [ ] CI build workflow passes on this PR
- [ ] Deploy workflow builds successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)