### PR TITLE
[codex] Add context-like-code blog draft

### DIFF
--- a/content/posts/treating-context-like-code.md
+++ b/content/posts/treating-context-like-code.md
@@ -1,0 +1,100 @@
+---
+title: "Treating Context Like Code"
+date: 2026-07-05T00:00:00-07:00
+draft: false
+---
+
+The more I use coding agents and LLMs for real work, the less I think of prompts as throwaway text.
+
+A useful prompt is not just a question. It is a small interface. It carries assumptions, constraints, examples, preferences, and failure modes. A project instruction file is even more explicit: it tells an agent how to navigate a codebase, what quality bar to hold, which tools to prefer, and which boundaries not to cross. A context pack does the same thing for a domain. It packages durable facts, active goals, source notes, open questions, stale claims, and sensitive exclusions so an agent can reason from the right starting point.
+
+That makes context feel much closer to code than prose.
+
+Code changes behavior. Context changes behavior too. If I change a project instruction, a coding agent may edit different files, choose different tests, or apply a different standard of evidence. If I change a domain context pack, the same user question can produce a better answer, a worse answer, or a confident answer based on stale assumptions. The context is part of the system.
+
+Once I accepted that, the natural conclusion followed: context needs engineering discipline.
+
+## Raw memory is not the same as useful context
+
+One failure mode in personal AI systems is treating every past conversation as equally useful memory. That is tempting because LLMs make it easy to accumulate text. Chat transcripts, notes, project plans, documents, issue threads, and tool outputs all feel like they might be useful later.
+
+But raw history is noisy. It contains abandoned ideas, temporary assumptions, duplicated facts, sensitive details, stale tool names, and decisions that were later reversed. Injecting that directly into an agent is like linking a production service against a random build artifact because it happened to exist on disk.
+
+The better path is a pipeline:
+
+```text
+raw notes
+  -> source summaries
+  -> reviewed domain pages
+  -> context packs
+  -> agent instructions
+  -> evaluated behavior
+```
+
+Each step loses some volume and gains some intent. The goal is not to remember everything. The goal is to preserve the parts that should change future behavior.
+
+This is why I like a Git-backed markdown wiki as the core memory layer. Markdown keeps the content human-editable. Git gives me history, diffs, branches, review, and the ability to treat changes as deliberate. The wiki does not need to be the only interface. Notion can be a better human dashboard. ChatGPT Projects can be a better reasoning surface. But for agent-readable memory, plain files with version history are hard to beat.
+
+## Context has failure modes
+
+If context can change behavior, it can also fail.
+
+Some failures are obvious. A context pack may omit a critical constraint. It may include an outdated hardware fact. It may blur public and private material. It may give the agent too much irrelevant history and bury the important instruction.
+
+Other failures are subtler. The context may be technically accurate but not useful for the task. It may describe goals without defining decision rules. It may list tools without explaining when to use them. It may preserve a preference but not the reason behind it, making it harder to adapt when the situation changes.
+
+The software analogy helps here. We already know how to reason about this kind of thing in code. We define intended behavior. We identify edge cases. We write tests. We review changes. We look for regressions. We make small edits and observe whether the system improved.
+
+Context deserves the same treatment.
+
+For my own wiki, I have been experimenting with an evaluation-driven loop:
+
+```text
+context pack
+  -> rubric
+  -> judge result
+  -> targeted wiki edit
+  -> rerun
+```
+
+The rubric asks concrete questions about the compiled context. Does it include the decision rule? Does it mention the privacy boundary? Does it distinguish verified facts from open questions? Does it capture the source hierarchy? The judge result is not magic, and it is not a substitute for human review. It is a feedback loop. It points at gaps that would otherwise remain invisible until an agent made a bad assumption during real work.
+
+That loop changes the way I write context. I stop asking, "Did I document this topic?" and start asking, "Will this context cause the next agent session to behave correctly?"
+
+## Prompts become maintainable artifacts
+
+There is a big difference between a clever one-off prompt and a maintainable prompt.
+
+A one-off prompt can be messy. It only has to work once, in one conversation, with one human watching closely. A maintainable prompt has a longer life. It needs a name, a purpose, a scope, and enough structure that it can be reused without reconstructing the original mental state.
+
+The same applies to project instructions, agent preferences, model routing rules, workflow checklists, and eval rubrics. They should have owners. They should have version history. They should be easy to inspect. When they fail, the fix should land in the artifact, not only in the memory of the person who noticed the failure.
+
+This is also where privacy matters. A durable context system should not casually mix everything together. Public biography material, professional notes, hobby planning, family logistics, financial records, and operational details do not belong in one undifferentiated memory pile. The artifact needs boundaries. Some context is safe to publish. Some is safe to use locally but not share. Some should be summarized into general lessons and then excluded from public outputs entirely.
+
+Good context engineering includes those exclusions explicitly.
+
+## The interesting part is behavioral drift
+
+The hard part is not writing the first version of a prompt or context pack. The hard part is keeping it correct as the world changes.
+
+Tools change. Model behavior changes. Project goals change. A preference that was useful six months ago can become noise. A fact that was once verified can become stale. A workflow that worked for one repository can be too heavy for another.
+
+That is why I want context artifacts to carry open questions and stale-claim registers, not only facts. A strong context pack does not pretend everything is known. It tells the agent where to be careful. It says which claims need verification. It separates durable principles from temporary observations.
+
+That small habit changes agent behavior in a practical way. Instead of confidently repeating an old assumption, the agent has permission to inspect, ask, or verify.
+
+## The broader pattern
+
+This feels familiar because it is the same engineering taste that shows up in infrastructure automation and reliability work.
+
+Infrastructure as code worked because it turned operational knowledge into versioned, reviewable, testable artifacts. Runbooks improved incident response because they made tacit operational judgment explicit. Service catalogs, ownership maps, deployment pipelines, and postmortems all exist for the same reason: complex systems get safer when important behavior is written down, maintained, and tested against reality.
+
+LLM context is another version of that problem.
+
+The agent is not only responding to the user. It is responding to the operating environment we give it: files, instructions, memories, tools, examples, constraints, and feedback loops. If that environment is accidental, the behavior will be accidental. If that environment is engineered, the behavior has a chance to improve over time.
+
+Treating context like code does not mean making everything heavyweight. It means taking the behavior seriously.
+
+Write the context down. Keep it small enough to maintain. Version it. Review it. Test the important parts. Delete stale claims. Preserve privacy boundaries. Improve the artifact when the agent fails.
+
+The prompt is not the product. The behavior is.

--- a/docs/blog-pipeline.md
+++ b/docs/blog-pipeline.md
@@ -1,0 +1,75 @@
+# Blog Pipeline
+
+Weekly publishing plan for `ranjib.github.io`, derived from the personal website content and the local knowledge graph at `/Users/ranjib/workspace/llm-wiki-ranjib`.
+
+Assumptions:
+
+- Cadence: one post per week.
+- Start date: Sunday, July 5, 2026.
+- Preferred shape: personal technical essays grounded in lived projects, public artifacts, and safe hobby notes.
+- Privacy rule: do not publish sensitive personal, family, finance, school, flight-training operational, or exact home-location details. Convert private notes into general lessons before drafting.
+
+## Editorial Lanes
+
+| Lane | Why it fits | Source areas |
+| --- | --- | --- |
+| Systems and reliability | Strongest public professional thread; already represented on the site | `Career Tech Themes`, `SRE`, `Platform Engineering`, public talks/blogs |
+| GenAI practice | Current active learning arc; useful to practitioners building with agents | `GenAI Learning`, `Agentic AI`, `Evaluation-Driven Context Engineering`, `Coding Agent Lab` |
+| Open source and physical computing | Distinctive personal/professional bridge through reef-pi | `reef-pi`, `reef-pi-*`, `3D Printing and Electronics` |
+| Hobbies as systems | Makes the site more personal while preserving an engineering voice | `Overlanding`, `Gardening`, `Reef Keeping`, public-safe travel retrospectives |
+| Career retrospectives | Durable essays from public talks and employer eras | `Professional Timeline`, `Career Tech Themes`, talk pages |
+
+## 16-Week Calendar
+
+| Week | Publish date | Working title | Lane | Source notes | Draft posture |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 2026-07-05 | Treating Context Like Code | GenAI practice | `GenAI Learning`, `Evaluation-Driven Context Engineering` | Explain why prompts, context packs, skills, and agent instructions deserve versioning, review, and evals. |
+| 2 | 2026-07-12 | The Through-Line From Chef to Agentic AI | Systems and GenAI | `Career Tech Themes`, `GenAI Learning` | Connect infrastructure-as-code discipline to context-as-code discipline. |
+| 3 | 2026-07-19 | reef-pi as a Small Open Source Platform | Open source and physical computing | `reef-pi`, `reef-pi-software-essence`, `reef-pi-hardware-ecosystem` | Follow-up to the existing reef-pi post, focused on platform boundaries and hardware abstraction. |
+| 4 | 2026-07-26 | What Incident Taxonomies Are Really For | Systems and reliability | `Career Tech Themes`, existing reliability post | Expand the taxonomy idea into a practical essay on learning from repeated failure classes. |
+| 5 | 2026-08-02 | My Personal LLM Wiki Operating Model | GenAI practice | `GenAI Learning`, `Wiki Operating Model`, `Context Pack Registry` | Describe raw notes to curated context packs to agent-readable memory. |
+| 6 | 2026-08-09 | Planning Overlanding Trips Like Reliability Reviews | Hobbies as systems | `Overlanding`, `Overlanding Safety Checklist`, `Trip Retrospectives` | Public-safe framing: route risk, constraints, verification, and go/no-go decisions. |
+| 7 | 2026-08-16 | Testing Infrastructure Was the Original Context Engineering | Systems and GenAI | `Career Tech Themes`, Agile 2015/TDD ops pages | Compare TDD in operations with evaluation-driven context engineering. |
+| 8 | 2026-08-23 | Gardening With an Operations Mindset | Hobbies as systems | `Gardening`, `Garden Seasonal Calendar`, `Garden Irrigation Zones` | Generalize zone-based planning, recurring tasks, source hierarchy, and feedback loops. |
+| 9 | 2026-08-30 | Why Documentation Is Part of the Product | Open source and physical computing | `reef-pi-publications`, Adafruit guide references, existing reef-pi post | Use reef-pi guides and community support as the example. |
+| 10 | 2026-09-06 | Model Routing Is an Engineering Decision | GenAI practice | `Model Routing Matrix`, `Coding Agent Lab`, `Local LLM Workstation` | Discuss quality/cost/speed/privacy tradeoffs without making time-sensitive model claims. |
+| 11 | 2026-09-13 | From Service Discovery to Safer Defaults | Systems and reliability | `Career Tech Themes`, Consul at PagerDuty, Platform Engineering | A career-retrospective essay on platforms making safe paths easier. |
+| 12 | 2026-09-20 | Building Hobby Systems That Survive Real Life | Hobbies as systems | `reef-pi`, `Gardening`, `Overlanding`, `3D Printing and Electronics` | Cross-hobby essay: maintenance, observability, constraints, and repairability. |
+| 13 | 2026-09-27 | The Weekly GenAI Review | GenAI practice | `GenAI Weekly Reviews`, `GenAI Skill Matrix` | Turn the review schema into a public template and personal learning method. |
+| 14 | 2026-10-04 | Capacity Planning as Product Thinking | Systems and reliability | Uber public blog pages, `Career Tech Themes` | Public-source essay on ML-assisted capacity safety and operational decision loops. |
+| 15 | 2026-10-11 | A Public Knowledge Graph for a Personal Website | GenAI practice | `Public Site Plan`, `Public Professional Footprint`, `scripts/check_public_leaks.py` | Explain how the website can be fed from a curated knowledge graph with privacy checks. |
+| 16 | 2026-10-18 | The Same Engineering Taste Across Work and Hobbies | Career retrospective | `Professional Timeline`, `reef-pi`, `Overlanding`, `Gardening` | Meta essay tying together reliability, automation, physical systems, and learning. |
+
+## Backlog
+
+| Title | Lane | Notes |
+| --- | --- | --- |
+| What I Learned Maintaining Chef Before Platform Engineering Had a Name | Career retrospective | Use only public Chef talks, award, and `chef-lxc` history. |
+| Containers Before Containers Were Boring | Career retrospective | LXC, chef-lxc, CI/CD for ops; good historical essay. |
+| The Difference Between Automation and Autonomy | Systems and GenAI | Bridge ML capacity work and agentic workflows. |
+| A Reef Tank Is a Distributed System With Water | Open source and physical computing | Good personal voice; avoid overclaiming. |
+| The Case for Small, Durable Open Source Projects | Open source and physical computing | reef-pi community, hardware ecosystem, documentation. |
+| Source Hierarchies for Personal AI Systems | GenAI practice | UCANR/CIMIS-style source hierarchy generalized to AI memory. |
+| What My Garden Taught Me About Feedback Loops | Hobbies as systems | Seasonal observations, plant records, irrigation. |
+| Trip Retrospectives for Overlanding | Hobbies as systems | Public-safe format: route, constraints, surprises, next changes. |
+| A Personal Website as a Long-Term Memory Interface | GenAI practice | Site as public projection of private knowledge graph. |
+| How to Write Publicly From Private Notes | GenAI practice | Sanitization, source maps, privacy gates, public-safe summaries. |
+
+## Weekly Workflow
+
+1. Monday: choose the next topic and copy source page names into the draft issue or note.
+2. Tuesday: outline the post with thesis, three sections, and public-source boundary.
+3. Wednesday: draft 800-1,200 words.
+4. Thursday: edit for privacy, specificity, and duplicated ideas.
+5. Friday: add links and public sources.
+6. Saturday: run the knowledge-graph public leak checks if content was exported from the wiki.
+7. Sunday: publish.
+
+## Draft Checklist
+
+- The post has one clear thesis.
+- The article can stand alone without private context.
+- Any private source page is paraphrased into a general lesson.
+- No family logistics, finance details, exact home operations, active flight-training details, or sensitive personal records are included.
+- Public claims link to public artifacts when available.
+- The title fits the existing site tone: direct, reflective, and engineering-oriented.


### PR DESCRIPTION
## Summary
- add the first weekly blog post, `Treating Context Like Code`
- add a 16-week blog pipeline document derived from the knowledge graph
- keep the post public-safe by focusing on method, privacy boundaries, and eval-driven context work

## Validation
- `git diff --cached --check` before commit
- `HUGO_CACHEDIR=/Users/ranjib/workspace/ranjib.github.io/.hugo_cache hugo --minify`

Closes #27