### PR TITLE
[codex] Publish context-like-code blog now

### DIFF
--- a/content/posts/treating-context-like-code.md
+++ b/content/posts/treating-context-like-code.md
@@ -1,6 +1,6 @@
 ---
 title: "Treating Context Like Code"
-date: 2026-07-05T00:00:00-07:00
+date: 2026-06-28T00:00:00-07:00
 draft: false
 ---
 


### PR DESCRIPTION
## Summary
- change `Treating Context Like Code` from the planned 2026-07-05 date to 2026-06-28
- make the post eligible for the normal Hugo deploy without `--buildFuture`

## Validation
- `git diff --check`
- `HUGO_CACHEDIR=/Users/ranjib/workspace/ranjib.github.io/.hugo_cache hugo --minify --destination /tmp/ranjib-site-datefix`
- confirmed `/posts/treating-context-like-code/index.html` is generated in the normal build